### PR TITLE
[feat] layout 초기 구현#47

### DIFF
--- a/Frontend/front-app/src/app/globals.css
+++ b/Frontend/front-app/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #D9D9D9;
   --foreground: #171717;
 }
 

--- a/Frontend/front-app/src/app/layout.tsx
+++ b/Frontend/front-app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { styleText } from "util";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,11 +24,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} relative antialiased bg-gray-300 h-screen overflow-hidden flex items-end justify-center p-8 pb-12`}
       >
-        {children}
+        <header className="absolute top-10 text-center text-4xl">
+          백(BACK) 다방
+        </header>
+        <div className="absolute bg-white rounded-2xl shadow-xl/30 w-235 h-144 top-29 p-5 overflow-y-auto">
+          {children}
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
## 📌 작업 내용
- 프론트 초기 레이아웃 구현했습니다.

## 🔗 관련 이슈
- close #47 

## 🛠 변경 사항
- [ ] 기능 구현

## 🧪 테스트 내용
- [ ] 로컬 테스트 완료
<img width="1918" height="966" alt="스크린샷 2025-12-16 165620" src="https://github.com/user-attachments/assets/0e4b4e74-0b83-4f46-b5b3-059f50240329" />


## 📎 참고 사항
- layout.tsx, global.css 파일 수정
