### PR TITLE
[refactor] 레이아웃 & 주문 관리 페이지 스크롤 수정#74

### DIFF
--- a/Frontend/front-app/src/app/admin/orders/page.tsx
+++ b/Frontend/front-app/src/app/admin/orders/page.tsx
@@ -98,7 +98,7 @@ export default function Page() {
             </div>
             
             {/* 스크롤 가능한 주문 목록 */}
-            <div className="flex-1 overflow-y-auto pr-2 space-y-3">
+            <div className="flex-1 overflow-y-auto space-y-3">
                 {filteredOrders.length === 0 ? (
                     <div className="text-center text-gray-500 mt-8">
                         해당 상태의 주문이 없습니다.

--- a/Frontend/front-app/src/app/layout.tsx
+++ b/Frontend/front-app/src/app/layout.tsx
@@ -25,21 +25,23 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko">
+    <html lang="ko" className="h-screen overflow-hidden">
       <head>
         <link
           rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.css"
         />
       </head>
-      <body className="antialiased bg-gray-300 min-h-screen">
-        <header className="pt-10 text-center text-4xl font-bold">
+      <body className="antialiased bg-gray-300 h-screen overflow-hidden flex flex-col">
+        <header className="pt-10 pb-6 text-center text-4xl font-bold">
           <Link href={`/`}>백(BACK) 다방</Link>
         </header>
 
-        <main className="mx-auto max-w-6xl px-6 py-8">
-          <div className="bg-white rounded-2xl shadow-xl/30 p-5 max-h-[calc(100vh-180px)] overflow-y-auto">
-            {children}
+        <main className="mx-auto max-w-6xl px-6 pb-8 flex-1 w-full overflow-hidden">
+          <div className="bg-white rounded-2xl shadow-xl/30 overflow-hidden h-full flex">
+            <div className="overflow-y-auto p-5 flex-1">
+              {children}
+            </div>
           </div>
         </main>
       </body>


### PR DESCRIPTION
## 📌 작업 내용
- 레이아웃 스크롤 -> rounded 적용 안 됨 수정했습니다.
- 주문 관리 페이지에서 주문 관리 헤더랑 탭은 고정해놓고 아이템들만 스크롤 가능하도록 수정하였습니다.
- 아이템이 없으면 박스 작아지는 문제 수정하였습니다.

## 🔗 관련 이슈
- close #74

## 🛠 변경 사항
- [ ] 버그 수정
- [ ] 리팩토링


## 🧪 테스트 내용
- [ ] 로컬 테스트 완료

<img width="1550" height="838" alt="image" src="https://github.com/user-attachments/assets/21473143-cdfe-4122-af7d-14d00a2d7dfe" />

<img width="624" height="865" alt="image" src="https://github.com/user-attachments/assets/f7192bc0-b06f-4819-8f44-49b1a99c8fb9" />

<img width="1551" height="826" alt="image" src="https://github.com/user-attachments/assets/cbd57585-37a7-4cf5-8854-b30fd0dec74d" />

<img width="1618" height="841" alt="image" src="https://github.com/user-attachments/assets/5be0dfcc-da42-4115-8d4a-99ea64f8bdeb" />

<img width="617" height="865" alt="image" src="https://github.com/user-attachments/assets/0d435745-7c95-4470-ba59-31faebb908b7" />

## 📎 참고 사항
- layout.tsx 수정하였습니다.
