### PR TITLE
[fix] 프론트 배송 상태 한글로 매핑#92

### DIFF
--- a/Frontend/front-app/src/app/orders/[email]/[orderId]/page.tsx
+++ b/Frontend/front-app/src/app/orders/[email]/[orderId]/page.tsx
@@ -12,6 +12,13 @@ export default function Page({ params }: { params: Promise<{ orderId: string }> 
     const [isLoading, setIsLoading] = useState(true);
     const { orderId } = use(params);
 
+    const DELIVERY_STATUS_MAP: Record<string, string> = {
+        "CONFIRM": "주문 확인",
+        "READY": "배송 준비 중",
+        "SHIPPING": "배송 중",
+        "DELIVERED": "배송 완료",
+    };
+
     const router = useRouter();
     const deletePost = (id: string) => {
     apiFetch(`/api/v1/order/${id}`, {
@@ -46,7 +53,7 @@ export default function Page({ params }: { params: Promise<{ orderId: string }> 
         <main style={{ padding: '20px' }}>
         <h1>주문 번호 {orderId}번 </h1>
         <p>총 수량: {order.totalQuantity}개 | 총 가격: {order.totalPrice}원</p>
-            <p>배송 상태: {order.deliveryStatus} (예정일: {order.deliveryDate})</p>
+            <p>배송 상태: {DELIVERY_STATUS_MAP[order.deliveryStatus]} (예정일: {order.deliveryDate})</p>
 
             <hr style={{ margin: '20px 0' }} />
 

--- a/Frontend/front-app/src/app/orders/[email]/page.tsx
+++ b/Frontend/front-app/src/app/orders/[email]/page.tsx
@@ -12,6 +12,12 @@ export default function Page({ params }: { params: Promise<{ email: string }> })
   const [isLoading, setIsLoading] = useState(true);
   const { email } = use(params);
 
+  const DELIVERY_STATUS_MAP: Record<string, string> = {
+      "CONFIRM": "주문 확인",
+      "READY": "배송 준비 중",
+      "SHIPPING": "배송 중",
+      "DELIVERED": "배송 완료",
+  };
 
   useEffect(() => {
     apiFetch(`/api/v1/orders/${email}`)
@@ -50,7 +56,7 @@ export default function Page({ params }: { params: Promise<{ email: string }> })
                 <p>총 수량: {order.totalQuantity}</p>
                 <p>총 가격: {order.totalPrice}</p>
                 <p>배송 날짜: {order.deliveryDate}</p>
-                <p>배송 상태: {order.deliveryStatus}</p>
+                <p>배송 상태: {DELIVERY_STATUS_MAP[order.deliveryStatus as string]}</p>
               </div>
             </Link>
           ))}


### PR DESCRIPTION
## 📌 작업 내용
- 이메일로 주문 내역 다건 조회, 단건 조회에서 배송 상태 한글로 수정하였습니다.

## 🔗 관련 이슈
- close #92

## 🛠 변경 사항
- [ ] 버그 수정
- [ ] 리팩토링

## 🧪 테스트 내용
- [ ] 로컬 테스트 완료
- 변경 전 
<img width="1493" height="838" alt="스크린샷 2025-12-18 093857" src="https://github.com/user-attachments/assets/2643d80c-9ae3-4784-ad16-8e52eebb2d32" />
- 변경 후
<img width="1411" height="818" alt="스크린샷 2025-12-18 100230" src="https://github.com/user-attachments/assets/3fc0c325-4a7e-4a5e-869b-0bd5dc914318" />


## 📎 참고 사항
