### PR TITLE
[refactor] 주문 상세 페이지 UI 제작완료

### DIFF
--- a/Frontend/front-app/src/app/orders/[email]/[orderId]/page.tsx
+++ b/Frontend/front-app/src/app/orders/[email]/[orderId]/page.tsx
@@ -4,87 +4,149 @@ import { use, useEffect, useState } from "react";
 import { apiFetch } from "@/lib/backend/client";
 import { OrderResponseDto } from "@/type/orderResponse";
 import { OrderProductDto } from "@/type/orderProduct";
-import Link from "next/link"; // Next.js의 Link 컴포넌트를 가져옵니다.
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { formatWon } from "@/lib/frontend/tools";
 
-export default function Page({ params }: { params: Promise<{ orderId: string }> }) {    
-    const [order, setOrder] = useState<OrderResponseDto | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const { orderId } = use(params);
+export default function Page({ params }: { params: Promise<{ orderId: string }> }) {
+  const [order, setOrder] = useState<OrderResponseDto | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const { orderId } = use(params);
+  const router = useRouter();
 
-    const DELIVERY_STATUS_MAP: Record<string, string> = {
-        "CONFIRM": "주문 확인",
-        "READY": "배송 준비 중",
-        "SHIPPING": "배송 중",
-        "DELIVERED": "배송 완료",
-    };
+  const DELIVERY_STATUS_MAP: Record<string, string> = {
+    "CONFIRM": "주문 확인",
+    "READY": "배송 준비 중",
+    "SHIPPING": "배송 중",
+    "DELIVERED": "배송 완료",
+  };
 
-    const router = useRouter();
-    const deletePost = (id: string) => {
+
+  const STATUS_STYLE_MAP: Record<string, string> = {
+    CONFIRM: "bg-gray-200 text-gray-800",
+    READY: "bg-blue-100 text-blue-800",
+    SHIPPING: "bg-yellow-100 text-yellow-800",
+    DELIVERED: "bg-green-100 text-green-800",
+  };
+
+  const deletePost = (id: string) => {
+    if (!order) { return}
     apiFetch(`/api/v1/order/${id}`, {
       method: "DELETE",
     }).then((data) => {
-      alert(data.msg);
-      router.replace(`/orders`);
+      alert(data.msg || "주문이 취소되었습니다.");
+      router.replace(`/orders/${order.email}`);
     });
   };
 
-    useEffect(() => {
-        apiFetch(`/api/v1/order/${orderId}`)
-          .then((data) => {
-                setOrder(data); 
-            })
-          .catch(error => {
-                console.error(`주문 ${orderId} 상세 내역 조회 중 오류 발생:`, error);
-            })
-            .finally(() => {
-                setIsLoading(false);
-            });
-    }, []); 
+  useEffect(() => {
+    apiFetch(`/api/v1/order/${orderId}`)
+      .then((data) => setOrder(data))
+      .catch((error) => console.error("오류 발생:", error))
+      .finally(() => setIsLoading(false));
+  }, [orderId]);
 
-    if (isLoading) {
-        return <main style={{ padding: '20px' }}><h2>주문 내역 로딩 중...</h2></main>;
-    }
-    if (!order) { 
-        return <main style={{ padding: '20px' }}><h1>주문 번호 {orderId}번</h1><p>주문 상세 정보를 찾을 수 없습니다.</p></main>;
-    }
-
+  if (isLoading) {
     return (
-        <main style={{ padding: '20px' }}>
-        <h1>주문 번호 {orderId}번 </h1>
-        <p>총 수량: {order.totalQuantity}개 | 총 가격: {order.totalPrice}원</p>
-            <p>배송 상태: {DELIVERY_STATUS_MAP[order.deliveryStatus]} (예정일: {order.deliveryDate})</p>
-
-            <hr style={{ margin: '20px 0' }} />
-
-            <h2> 주문 상품 목록</h2>
-            
-            {/* products의 이름만 출력 */}
-            {order.products && order.products.length > 0 ? (
-                <ul>
-                    {order.products.map((product: OrderProductDto) => (
-                        // key는 목록 렌더링 시 중요하며, productId가 고유하다고 가정합니다.
-                        <li key={product.productId} style={{ marginBottom: '5px' }}>
-                            {product.productName} (수량: {product.quantity}개, 가격: {product.price}원)
-                        </li>
-                    ))}
-                </ul>
-            ) : (
-                <p>주문된 상품이 없습니다.</p>
-            )}
-             <div className="flex gap-2">
-            <button
-            className="p-2 rounded border"
-            onClick={() =>
-                confirm(`${orderId}번 주문을 취소하시겠습니까?`) &&
-                deletePost(orderId)
-            }>
-            주문 취소
-            </button>
-            <Link className="p-2 rounded border" href={`${orderId}/edit`}>
-            주문수정
-            </Link>
-        </div>
-        </main>
+      <div className="flex justify-center items-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
     );
+  }
+
+  if (!order) {
+    return (
+      <main className="max-w-2xl mx-auto mt-10 p-6 text-center bg-red-50 rounded-lg border border-red-200">
+        <h1 className="text-xl font-bold text-red-600">주문을 찾을 수 없습니다.</h1>
+      </main>
+    );
+  }
+
+
+  return (
+    <main className="max-w-3xl mx-auto py-10 px-4">
+      <div className="bg-white shadow-xl rounded-2xl overflow-hidden border border-gray-100">
+        {/* 헤더 섹션 */}
+        <div className="bg-gray-50 border-b p-6 flex justify-between items-center">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-800">{orderId}번 주문 상세</h1>
+          </div>
+          <span className={`px-4 py-1.5 rounded-full text-sm font-bold ${STATUS_STYLE_MAP[order.deliveryStatus]}`}>
+            {DELIVERY_STATUS_MAP[order.deliveryStatus]}
+          </span>
+        </div>
+
+        <div className="p-6 space-y-8">
+          {/* 요약 정보 섹션 */}
+          <section className="grid grid-cols-2 gap-4">
+            <div className="p-4 bg-blue-50 rounded-xl border border-blue-100">
+              <p className="text-sm text-blue-600 font-medium">총 결제 금액</p>
+              <p className="text-2xl font-extrabold text-blue-700">{formatWon(order.totalPrice)}원</p>
+            </div>
+            <div className="p-4 bg-gray-50 rounded-xl border border-gray-100">
+              <p className="text-sm text-gray-600 font-medium">배송 예정일</p>
+              <p className="text-xl font-bold text-gray-800">{order.deliveryDate || "미정"}</p>
+            </div>
+          </section>
+
+          {/* 상품 목록 섹션 */}
+          <section>
+            <h2 className="text-lg font-semibold mb-4 text-gray-700 flex items-center">
+              <span className="w-1 h-5 bg-blue-500 rounded-full mr-2"></span>
+              주문 상품
+            </h2>
+            <div className="bg-gray-50 rounded-xl p-4 border border-gray-100">
+              <ul className="divide-y divide-gray-200">
+                {order.products.map((product: OrderProductDto) => (
+                  <li key={product.productId} className="py-4 flex justify-between items-center">
+                    <div className="flex flex-col">
+                      <span className="font-medium text-gray-800">{product.productName}</span>
+                      <span className="text-sm text-gray-500">수량: {product.quantity}개</span>
+                    </div>
+                    <span className="font-semibold text-gray-700">{formatWon(product.price * product.quantity)}원</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+
+          {/* 배송 정보 섹션 (상세보기용 추가) */}
+          <section>
+            <h2 className="text-lg font-semibold mb-4 text-gray-700 flex items-center">
+              <span className="w-1 h-5 bg-blue-500 rounded-full mr-2"></span>
+              배송지 정보
+            </h2>
+            <div className="p-4 border border-gray-200 rounded-xl space-y-2">
+              <p className="text-gray-800"><span className="font-medium text-gray-500 mr-2">주소:</span> {order.address || "정보 없음"}</p>
+              <p className="text-gray-800"><span className="font-medium text-gray-500 mr-2">우편번호:</span> {order.zipCode || "정보 없음"}</p>
+            </div>
+          </section>
+
+          {/* 하단 버튼 액션: 배송 완료(DELIVERED)가 아닐 때만 표시 */}
+            {order.deliveryStatus !== "DELIVERED" && (
+            <div className="flex gap-3 pt-6 border-t border-gray-100">
+                <button
+                onClick={() => confirm(`${orderId}번 주문을 취소하시겠습니까?`) && deletePost(orderId)}
+                className="flex-1 px-4 py-3 border border-red-200 text-red-600 rounded-lg hover:bg-red-50 font-medium transition-colors"
+                >
+                주문 취소하기
+                </button>
+                <Link
+                href={`${orderId}/edit`}
+                className="flex-[2] px-4 py-3 bg-gray-800 text-white text-center rounded-lg hover:bg-gray-900 font-bold shadow-lg transition-all active:scale-[0.98]"
+                >
+                주문 정보 수정
+                </Link>
+            </div>
+            )}
+        </div>
+      </div>
+      
+      <div className="mt-6 text-center">
+        <button onClick={() => router.push(`/orders/${order.email}`)} className="text-gray-400 hover:text-gray-600 text-sm underline underline-offset-4">
+          전체 주문 목록으로 돌아가기
+        </button>
+      </div>
+    </main>
+  );
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
<img width="773" height="751" alt="주문 상세 페이지" src="https://github.com/user-attachments/assets/39efcc81-6c1d-4ace-9e67-7de391158293" />

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 상세 페이지 UI를 제작했습니다. 주문 수정 페이지와 유사하게 제작했습니다.
UI통일성을 위해 STATUS_STYLE_MAP를 보고 그대로 사용했습니다.
주문 취소 하기 버튼을 누르면 모달창으로 주문을 취소하겠습니까? 가 뜨고 확인 시 
전체 주문 목록으로 돌아갑니다. 주문 정보 수정을 누르면 주문 수정 페이지로 이동합니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
