### PR TITLE
[fix] 주문 확인만 수정 & 헤더 고정#101

### DIFF
--- a/Frontend/front-app/src/app/admin/products/create/page.tsx
+++ b/Frontend/front-app/src/app/admin/products/create/page.tsx
@@ -88,7 +88,7 @@ export default function Home() {
               placeholder="https://example.com/image.jpg"
               value={imageUrl}
               onChange={(e) => setImageUrl(e.target.value)}
-              className="w-full border px-3 py-2 rounded"
+              className="w-full border border-gray-300 px-3 py-2 rounded"
             />{" "}
           </div>
           {/* 가격 */}
@@ -137,7 +137,7 @@ export default function Home() {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="flex justify-center gap-10 mt-50">
+      <div className="flex justify-center gap-5 mt-20">
         <button
           type="button"
           onClick={() => router.push("/admin/products")}

--- a/Frontend/front-app/src/app/admin/products/page.tsx
+++ b/Frontend/front-app/src/app/admin/products/page.tsx
@@ -35,11 +35,10 @@ export default function Home() {
   }, []);
 
   return (
-    <div>
-      <div className="mx-auto max-w-6xl px-4 py-4">
-        <h2 className="text-2xl font-bold">상품 목록</h2>
+      <div className="flex flex-col h-full mx-auto max-w-6xl px-4 py-4">
+        <h2 className="text-2xl font-bold flex-shrink-0">상품 목록</h2>
         {/* 상품 목록*/}
-        <div className="mt-6 space-y-4 my-4">
+        <div className="flex-1 overflow-y-auto space-y-3 mt-6 space-y-4 my-4">
           {products.length === 0 && (
             <p className="text-center text-gray-500">등록된 상품이 없습니다.</p>
           )}
@@ -100,15 +99,13 @@ export default function Home() {
             </div>
           ))}
         </div>
-        <div className="border-t p-4">
-          <Link
+        <hr className="border-1 border-gray-200 my-5"></hr>
+        <Link
             href="/admin/products/create"
-            className="block w-full border rounded py-2 text-center text-lg hover:bg-gray-100"
+            className="block w-full border-2 border-gray-300 rounded py-2 text-center text-lg hover:bg-gray-100"
           >
-            +
-          </Link>
-        </div>
+            +  
+        </Link>
       </div>
-    </div>
   );
 }

--- a/Frontend/front-app/src/app/orders/[email]/[orderId]/page.tsx
+++ b/Frontend/front-app/src/app/orders/[email]/[orderId]/page.tsx
@@ -123,7 +123,7 @@ export default function Page({ params }: { params: Promise<{ orderId: string }> 
           </section>
 
           {/* 하단 버튼 액션: 배송 완료(DELIVERED)가 아닐 때만 표시 */}
-            {order.deliveryStatus !== "DELIVERED" && (
+            {order.deliveryStatus == "CONFIRM" && (
             <div className="flex gap-3 pt-6 border-t border-gray-100">
                 <button
                 onClick={() => confirm(`${orderId}번 주문을 취소하시겠습니까?`) && deletePost(orderId)}

--- a/Frontend/front-app/src/app/orders/[email]/page.tsx
+++ b/Frontend/front-app/src/app/orders/[email]/page.tsx
@@ -48,9 +48,9 @@ export default function Page({ params }: { params: Promise<{ email: string }> })
     );
   }
   return (
-    <div className="mx-auto max-w-4xl px-4 py-6">
+    <div className="flex flex-col h-full mx-auto max-w-5xl px-4 py-6">
       {/* 제목 */}
-      <header className="mb-6">
+      <header className="mb-6 flex-shrink-0">
         <h1 className="text-2xl font-bold tracking-tight text-gray-900">
           {decodeURIComponent(email)} 님의 주문 내역
         </h1>
@@ -59,7 +59,8 @@ export default function Page({ params }: { params: Promise<{ email: string }> })
         </p>
       </header>
 
-      {/* 주문 목록 */}
+      <div className="flex-1 overflow-y-auto space-y-3">
+        {/* 주문 목록 */}
       {orders && orders.length > 0 ? (
         <div className="space-y-4">
           {orders.map((order) => (
@@ -126,6 +127,7 @@ export default function Page({ params }: { params: Promise<{ email: string }> })
           </p>
         </div>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용
- 사용자 주문 확인 내역에서 주문 확인만 수정 가능하도록 수정했습니다.
- 상품 추가 화면 & 주문 내역 확인에서 헤더는 고정하고 아이템만 스크롤 가능하도록 수정했습니다.

## 🔗 관련 이슈
- close #101

## 🛠 변경 사항
- [ ] 기능 구현
- [ ] 버그 수정

## 🧪 테스트 내용
- [ ] 로컬 테스트 완료
- 상품 추가 화면 스크롤 변경 & 하단 버튼 border 색 통일 & 크기 통일
<img width="1401" height="836" alt="image" src="https://github.com/user-attachments/assets/e2c583de-15c9-48e2-a05e-f467fafc09a4" />
- 주문 내역 헤더 고정 
<img width="1482" height="807" alt="image" src="https://github.com/user-attachments/assets/f780a7ae-2736-4c55-85fa-61d10dfd2291" />


## 📎 참고 사항
