### PR TITLE
[fix] 상품 삭제 오류 수정#109

### DIFF
--- a/Backend/src/main/java/com/back/domain/product/controller/ApiV1ProductController.java
+++ b/Backend/src/main/java/com/back/domain/product/controller/ApiV1ProductController.java
@@ -69,7 +69,7 @@ public class ApiV1ProductController {
 
         return new RsData<>(
                 "200-1",
-                "%s 상품이 삭제되었습니다.".formatted(product.getName())
+                "%s 상품이 삭제 처리되었습니다.".formatted(product.getName())
         );
     }
     @PutMapping("/product/{id}")

--- a/Backend/src/main/java/com/back/domain/product/entity/Product.java
+++ b/Backend/src/main/java/com/back/domain/product/entity/Product.java
@@ -2,11 +2,11 @@ package com.back.domain.product.entity;
 
 import com.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Entity
 @Getter
+@AllArgsConstructor
 @Builder
 public class Product extends BaseEntity {
     @Column(nullable = false, length = 50)
@@ -24,11 +24,19 @@ public class Product extends BaseEntity {
     @Column(length = 300)
     private String imageUrl;
 
+    @Column(nullable = false)
+    private boolean deleted;
+
+    public void delete() {
+        this.deleted = true;
+    }
+
     public Product(String name, int price, String description, String imageUrl) {
         this.name = name;
         this.price = price;
         this.description = description;
         this.imageUrl = imageUrl;
+        this.deleted = false;
 
     }
 

--- a/Backend/src/main/java/com/back/domain/product/repository/ProductRepository.java
+++ b/Backend/src/main/java/com/back/domain/product/repository/ProductRepository.java
@@ -3,7 +3,11 @@ package com.back.domain.product.repository;
 import com.back.domain.product.entity.Product;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product,Integer> {
+    List<Product> findByDeletedFalse();
     boolean existsByName(@NotBlank String name);
 }

--- a/Backend/src/main/java/com/back/domain/product/service/ProductService.java
+++ b/Backend/src/main/java/com/back/domain/product/service/ProductService.java
@@ -20,17 +20,18 @@ public class ProductService {
     }
 
     public List<Product> findAll() {
-        return productRepository.findAll();
+        return productRepository.findByDeletedFalse();
     }
 
     public Optional<Product> findById(int id) {
         return productRepository.findById(id);
     }
+
     public void modify(Product product, String name, int price,String description, String imageUrl) {
         product.modify(name, price, description, imageUrl);
     }
     public void delete(Product product) {
-        productRepository.delete(product);
+        product.delete();
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 작업 내용
- Product에 deleted 필드 추가해서 삭제 하면 deleted=true
- findAllDeletedFalse로 deleted=false인 데이터들만 조회

## 🔗 관련 이슈
- close #109

## 🛠 변경 사항
- [ ] 버그 수정
- [ ] 리팩토링

## 🧪 테스트 내용
- [ ] 로컬 테스트 완료
- [ ] Postman / Swagger 테스트
- 아메리카노 삭제
<img width="1598" height="837" alt="스크린샷 2025-12-18 171434" src="https://github.com/user-attachments/assets/5d2c5d09-4a4a-4503-944b-eb4b5ca65ad4" />

- 주문 정보에 남아있음
<img width="1530" height="840" alt="스크린샷 2025-12-18 171504" src="https://github.com/user-attachments/assets/50444e60-b8ef-4b36-9806-9d107c60d125" />

## 📎 참고 사항
